### PR TITLE
Add the Chaostreff Bern Jabber Servers to the list of servers refusin…

### DIFF
--- a/1.md
+++ b/1.md
@@ -39,9 +39,9 @@ We intend to stop using untrusted certificates! [Manual for operators XMPP serve
 Servers that fail to verify certificates in cross-server connections
 
 * xmpp.honet.ch
-* jabber.chaostreffbern.ch
-* jabber.chaosbern.ch
-* jabber.chaostreff-bern.ch
+* [jabber.chaostreffbern.ch](https://chaostreffbern.ch/en/jabber.html)
+  * jabber.chaosbern.ch
+  * jabber.chaostreff-bern.ch
 
 ## Servers violated the execution of the manifest
 

--- a/1.md
+++ b/1.md
@@ -1,15 +1,15 @@
 
-# 1. Manifest to disable support s2s untrusted certificates
+# 1. Manifest to disable communication with servers that have untrusted certificates
 
 In the past, the certificates were worth the money. In the past, obtaining certificates was a difficult task.This forced the use of self-signed certificates in self-signed connections to preserve the federation.
 
-Currently, certificates have become free and anyone can get them. self-signed certificates can be swapped and user conversations are intercepted. We believe that the time has come to stop supporting self-signed certificates to increase user security.
+Currently, certificates have become free and anyone can get them. We believe that the time has come to stop supporting self-signed certificates to increase user security.
 
 Default settings Ejabberd and Prosody allow self-signed certificates:
 
 **Ejabberd:**
 ```
-mod_s2s_dialback: {}
+s2s_use_starttls: required
 
 ```
 **Prosody**
@@ -22,15 +22,13 @@ We intend to stop using untrusted certificates! [Manual for operators XMPP serve
 ## Servers in this list pledge not to accept connections with self-signed certificates.
 
 + [404.city](https://404.city)
-+ [xmpp.is](https://xmpp.is) + mirrors:
++ [xmpp.is](https://xmpp.is)
   + xmpp.co
   + xmpp.cx
   + xmpp.xyz
   + xmpp.fi
   + xmpp.si  
-+ [jabber.at](https://jabber.at) + mirrors:
-  + xmpp.zone
-  + xmpp.zone
++ [jabber.at](https://jabber.at)
 + [os.vu](https://os.vu)
 
 
@@ -39,6 +37,11 @@ We intend to stop using untrusted certificates! [Manual for operators XMPP serve
 ## Servers in this list refused to support the manifest
 
 Servers that fail to verify certificates in cross-server connections
+
+* xmpp.honet.ch
+* jabber.chaostreffbern.ch
+* jabber.chaosbern.ch
+* jabber.chaostreff-bern.ch
 
 ## Servers violated the execution of the manifest
 


### PR DESCRIPTION
I cannot support this proposal. To the best of my knowledge, certificates are easy to get only for certain situations.
Take, however this situation: A friend would like me to run XMPP services for their domain example.org on my server. Thus I need a valid certificate and have two options for that:
* optain a valid certificate for example.org. HOWEVER, this certificate could also be used to validate a website running under the same name. It is well possible that a friend trusts me to run their XMPP service but does not want me to have a certificate that in effect allows me to host a bogus website under their domain.
* Get a certificate with an SRV SAN entry. HOWEVER, as described below, now recognized CA can issue such certificates.

So both solutions are bad with the first one giving me access to resources I should not have the second one forcing me to self-sign a certificate. As long as this dilemma is not solved, I do not consider your proposal and adequate solution.

## The problem with SRV certificates
According to, secion 7.1.4.2.1 of the [CA/B forum Baseline Regulations](https://cabforum.org/wp-content/uploads/CA-Browser-Forum-BR-1.6.0.pdf) disallow CAs to issue certificates with SRV entries that are not of type `IP addresses` or `DNS names`. See the quote below
> This extension MUST contain at least one entry. Each entry MUST be either a dNSName containing the Fully-Qualified Domain Name or an iPAddress containing the IP address of a server. [...]

However, SAN entries are defined in [section 4.2.1.6 of RFC 5280](https://tools.ietf.org/html/rfc5280#section-4.2.1.6) which states
> The subjectAltName MAY carry additional name types through the use of the otherName field.  The format and semantics of the name are indicated through the OBJECT IDENTIFIER in the type-id field.  The name itself is conveyed as value field in otherName.

SRV SAN entries are defined in https://tools.ietf.org/html/rfc4985|RFC 4985 which states in section 2:
> This section defines the SRVName name as a form of otherName from the GeneralName structure in SubjectAltName defined in RFC 3280 [N2].