### PR TITLE
The project is called "Tor", not "TOR"

### DIFF
--- a/1.md
+++ b/1.md
@@ -69,7 +69,7 @@ Unfortunately, we faced resistance to the manifesto from uneducated administrato
 You can have your own CA, but this will require additional configuration efforts. You can set two certificates and the priority between using them.  Your second certificate will be available only to those who trust your certificate or your authorization center.
 
 
->Users of the TOR will not be able to connect to the server?
+>Users of the Tor will not be able to connect to the server?
 
 If you configure the server correctly, users will be able to connect to the hidden service.
 


### PR DESCRIPTION
The TOR acronym came about later and isn't actually the official name of the project.